### PR TITLE
Problem: SEGV when receiving messages

### DIFF
--- a/answerscripts.c
+++ b/answerscripts.c
@@ -140,13 +140,19 @@ static void received_msg_cb(PurpleAccount *account, char *who, char *buffer, Pur
 	} else {
 		status_msg = (char *) purple_savedstatus_get_message(purple_savedstatus_get_current());
 	}
+	//If purple_status_get_attr_string returns NULL for whatever reason, also as a precaution against purple_savedstatus_get_message doing the same
+	if (status_msg == NULL) {
+            status_msg = "";
+        }
 	//remote
 	const char *r_status_msg = NULL;
 	if (purple_status_type_get_attr(r_status_type, "message") != NULL) {
 		r_status_msg = purple_status_get_attr_string(r_status, "message");
-	} else {
-		r_status_msg = "";
 	}
+	//If purple_status_get_attr_string returns NULL for whatever reason
+	if (r_status_msg == NULL) {
+            r_status_msg = "";
+        }
 
 	//Export variables to environment
 	setenv(ENV_PREFIX "ACTION", action, 1);	//what happend: IM/CHAT/UNKNOWN, show setting dialog, event, etc...


### PR DESCRIPTION
Source: Seems to be libpurple's fault for returning NULL from
purple_status_get_attr_string()
Solution: Set r_status_msg to empty string after checking for NULL; as a
precaution also for status_msg

OS: Arch Linux AMD64
Pidgin version: 2.10.12devel
Libpurple: 2.10.12devel
Answerscripts: Commit 8c4afbb588909d8f2619abcd18d5fce8cb2e983a

Backtrace:
#0  0x00007ffff495c0ca in strlen () from /usr/lib/libc.so.6
#1  0x00007ffff4910b59 in __add_to_environ () from /usr/lib/libc.so.6
#2  0x00007fffe88bad77 in received_msg_cb (account=0x8c9050,
who=0xdf76e0 "XXXX", buffer=0xead5a0
"<FONT>*MEHR FIST*</FONT>", conv=0xf92730, flags=PURPLE_MESSAGE_RECV,
data=0x0) at answerscripts.c:161
#3  0x00007ffff5cfdd70 in purple_signal_emit_vargs () from
/usr/lib/libpurple.so.0
#4  0x00007ffff5cfdece in purple_signal_emit () from /usr/lib/libpurple.so.0
#5  0x00007ffff5cfc726 in serv_got_im () from /usr/lib/libpurple.so.0
#6  0x00007fffdd23ff05 in jabber_message_parse () from
/usr/lib/purple-2/libjabber.so.0
#7  0x00007fffdd23520b in jabber_process_packet () from
/usr/lib/purple-2/libjabber.so.0
#8  0x00007fffdd241cd4 in ?? () from /usr/lib/purple-2/libjabber.so.0
#9  0x00007ffff052f413 in ?? () from /usr/lib/libxml2.so.2
#10 0x00007ffff0534dba in ?? () from /usr/lib/libxml2.so.2
#11 0x00007ffff05368be in xmlParseChunk () from /usr/lib/libxml2.so.2
#12 0x00007fffdd24218d in jabber_parser_process () from
/usr/lib/purple-2/libjabber.so.0
#13 0x00007fffdd23143b in ?? () from /usr/lib/purple-2/libjabber.so.0
#14 0x000000000046990e in ?? ()
#15 0x00007ffff51e3c7a in g_main_context_dispatch () from
/usr/lib/libglib-2.0.so.0
#16 0x00007ffff51e4020 in ?? () from /usr/lib/libglib-2.0.so.0
#17 0x00007ffff51e4342 in g_main_loop_run () from /usr/lib/libglib-2.0.so.0
#18 0x00007ffff6d56467 in gtk_main () from /usr/lib/libgtk-x11-2.0.so.0
#19 0x0000000000431f19 in main ()

Local vars in received_msg_cb():
buddy = 0xafe080
presence = 0xafe110
action = 0x7fffe88bafe8 "IM"
roomname = 0x7fffe88bafeb ""
local_name = 0x8c8f50 "XXXX"
local_alias = 0x8c8f50 "XXXX"
highlighted = 0x7fffe88baffe "false"
remote_alias = 0xafe030 "XXXX"
group = 0xb7f230
from_group = 0xb7f0b0 "Buddys"
protocol_id = 0x8c8ff5 "jabber"
status = 0x8c5a70
type = 0x8c9270
r_status = 0xafe1e0
r_status_type = 0x8c9270
status_id = 0x7ffff5d5d5cc "available"
r_status_id = 0x7ffff5d5d5cc "available"
status_msg = 0x0
r_status_msg = 0x0
job = 0x113f400
fflags = 0