### PR TITLE
Reliable way to not respond to own messages

### DIFF
--- a/answerscripts.c
+++ b/answerscripts.c
@@ -110,7 +110,7 @@ static char received_msg_cb(PurpleAccount *account, char *who, char *buffer, Pur
 	if(local_alias == NULL) local_alias = local_name;
 
 	//Do not respond to messages sent by myself
-	if(strcmp(local_name, who) == 0) return 0;
+	if (flags & PURPLE_MESSAGE_SEND) return 0; 
 
 	//Was my nick said?
 	char *highlighted;


### PR DESCRIPTION
On chat's with multiple participants the previous check is not reliable. Has to do something how purple resolves the names and aliases. 

On chat's when it fails it goes into very dirty loop :D

I found that it sets a PURPLE_MESSAGE_SEND flag when it is about to respond to itself. 

PS!: Test it on your setup :)
